### PR TITLE
Do not create an output path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,4 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
     apt-get install -y r-base
 
-RUN mkdir /output/
 RUN Rscript -e "install.packages('adegenet')"


### PR DESCRIPTION
Minor patch to remove the creation of a output path directory, this should be created during the PCA plotting.